### PR TITLE
chore: Upgrade Node.js version from 18 to 20 in Dockerfile for build and production stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ===============================================
 # 🏗️ Build Stage - 애플리케이션 빌드
 # ===============================================
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 
 WORKDIR /usr/src/app
 
@@ -25,7 +25,7 @@ RUN npm ci --only=production && npm cache clean --force
 # ===============================================
 # 🚀 Production Stage - 실행 환경
 # ===============================================
-FROM node:18-alpine AS production
+FROM node:20-alpine AS production
 
 # 필요한 패키지 설치 (healthcheck용)
 RUN apk add --no-cache wget dumb-init


### PR DESCRIPTION
점검 결과 및 수정 방안은 다음과 같습니다.

1. Dockerfile: Node.js 버전 업그레이드 필요
현재 Dockerfile의 build/production 스테이지 모두 node:18-alpine을 사용하고 있습니다.
Node.js 20 이상을 요구하는 패키지가 있으므로, 아래와 같이 20 이상으로 변경해야 합니다.
수정 예시
2. main.ts: 포트 설정 적절
const port = process.env.PORT || 8080;로 Cloud Run의 포트 환경변수를 잘 반영하고 있습니다.
아래 부분만 있으면 정상입니다.
3. 기타 점검
Dockerfile에서 포트 8080을 EXPOSE 하고 있고, ENTRYPOINT/CMD도 정상입니다.
특별한 추가 수정 없이 Node.js 버전만 올리면 됩니다.
이제 Dockerfile의 Node.js 버전만 20 이상으로 올려 수정하겠습니다.

Dockerfile+2-2
Read main.ts, lines 31 to 40

수정 및 점검이 완료되었습니다.

Dockerfile의 Node.js 버전을 18-alpine → 20-alpine으로 모두 업그레이드했습니다.
main.ts는 이미 Cloud Run의 포트 환경변수(process.env.PORT)를 잘 반영하고 있어 추가 수정이 필요 없습니다.
이제 Docker 이미지를 다시 빌드하고 Cloud Run에 재배포하면 정상적으로 컨테이너가 기동될 가능성이 높습니다.
문제가 계속된다면 Cloud Run 로그에서 추가적인 런타임 에러를 확인해 주세요.